### PR TITLE
Allow Cyanogenmod to use this app with Lollipop

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,7 +5,7 @@
         or you will NOT be able to use your device.\nUse at your own risk!</string>
     <string name="title_activity_main">@string/app_name</string>
     <string name="confirmation_dialog_title">Confirm password change</string>
-    <string name="confirmation_dialog_message">Are you sure you wanto change the 
+    <string name="confirmation_dialog_message">Are you sure you want to change the 
         device encryption password?\nYou will need to enter the new password 
         at next boot, make sure you remember it!</string>
     <string name="invalid_password">Invalid password</string>

--- a/src/org/nick/cryptfs/passwdmanager/MainActivity.java
+++ b/src/org/nick/cryptfs/passwdmanager/MainActivity.java
@@ -100,7 +100,9 @@ public class MainActivity extends Activity implements OnClickListener {
                         selinuxPolicyPatched = SuShell.patchLollipopPolicy();
                     }
 
-                    boolean result = canGainSu && selinuxPolicyPatched;
+                    boolean cyanogenmod = SuShell.isCyanogenmod();
+
+                    boolean result = canGainSu && (selinuxPolicyPatched || cyanogenmod);
                     if (!result) {
                         return result;
                     }

--- a/src/org/nick/cryptfs/passwdmanager/SuShell.java
+++ b/src/org/nick/cryptfs/passwdmanager/SuShell.java
@@ -181,7 +181,7 @@ public class SuShell {
             File cmdFile = new File(path, cmd);
             if (cmdFile.exists()) {
                 if (DEBUG) {
-                    Log.d(TAG, "Found su at " + cmdFile.getAbsolutePath());
+                    Log.d(TAG, "Found " + cmd + " at " + cmdFile.getAbsolutePath());
                 }
 
                 return true;

--- a/src/org/nick/cryptfs/passwdmanager/SuShell.java
+++ b/src/org/nick/cryptfs/passwdmanager/SuShell.java
@@ -211,4 +211,23 @@ public class SuShell {
         return false;
     }
 
+    public static boolean isCyanogenmod() {
+        if (!findInPath("uname")) {
+            return false;
+        }
+
+        String cmd = "uname -a";
+        List<String> output = runWithShell(cmd);
+        if (output.isEmpty()) {
+            return false;
+        }
+
+        for (String line : output) {
+            if (line.contains("-CM-") || line.contains("-cyanogenmod-")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Cyanogenmod doesn't have `supolicy` patched on the system, so the app exits claiming it can't get root even though it can.  This fix checks if Cyanogenmod installed on the system and allows the app to continue if it is.

The code to detect Cyanogenmod is from this http://android.stackexchange.com/a/40063