### PR TITLE
Add support for CyanogenMod 13 (different "vdc cryptfs changepw" format)

### DIFF
--- a/src/org/nick/cryptfs/passwdmanager/CryptfsCommands.java
+++ b/src/org/nick/cryptfs/passwdmanager/CryptfsCommands.java
@@ -31,6 +31,10 @@ public class CryptfsCommands {
             + " cryptfs changepw pin %s";
     private static final String CRYPTFS_CHANGEPW_PASSWORD_CMD = VDC_CMD_PATH
             + " cryptfs changepw password %s";
+    private static final String CRYPTFS_CHANGEPW_PIN_CM_CMD = VDC_CMD_PATH
+            + " cryptfs changepw pin %s %s";
+    private static final String CRYPTFS_CHANGEPW_PASSWORD_CM_CMD = VDC_CMD_PATH
+            + " cryptfs changepw password %s %s";
 
     private static final String CRYPTFS_GETPWTYPE_CMD = VDC_CMD_PATH
             + " cryptfs getpwtype";
@@ -42,6 +46,7 @@ public class CryptfsCommands {
     private static final Pattern PIN_PATTERN = Pattern.compile("\\d+");
 
     public static final String PWTYPE_DEFAULT = "default";
+    public static final String DEFAULT_PASSWORD = "default_password";
 
     public CryptfsCommands() {
     }
@@ -158,14 +163,20 @@ public class CryptfsCommands {
 
     public static boolean changeCryptfsPasswordLollipop(String newPassword,
             String oldPassword) {
+        oldPassword = (oldPassword == null || "".equals(oldPassword)) ? DEFAULT_PASSWORD : oldPassword;
         String encodedNewPassword = IS_M ? newPassword : toHexAscii(newPassword);
+        String encodedOldPassword = IS_M ? oldPassword : toHexAscii(oldPassword);
+        boolean isCyanogenmod13 = IS_M && SuShell.isCyanogenmod();
 
-        String command = CRYPTFS_CHANGEPW_PASSWORD_CMD;
+        String command = isCyanogenmod13 ? CRYPTFS_CHANGEPW_PASSWORD_CM_CMD
+                                         : CRYPTFS_CHANGEPW_PASSWORD_CMD;
         if (PIN_PATTERN.matcher(newPassword).matches()) {
-            command = CRYPTFS_CHANGEPW_PIN_CMD;
+            command = isCyanogenmod13 ? CRYPTFS_CHANGEPW_PIN_CM_CMD
+                                      : CRYPTFS_CHANGEPW_PIN_CMD;
         }
         List<String> response = SuShell.run("su",
-                String.format(command, encodedNewPassword));
+                isCyanogenmod13 ? String.format(command, encodedOldPassword, encodedNewPassword)
+                                : String.format(command, encodedNewPassword));
 
         boolean changeResult = checkVdcResponse(response);
         boolean verifyResult = checkCryptfsPasswordLollipop(newPassword);
@@ -189,12 +200,17 @@ public class CryptfsCommands {
 
     private static boolean changePasswordNoVerifyLollipop(String newPassword) {
         String encodedPassword = IS_M ? newPassword : toHexAscii(newPassword);
-        String command = CRYPTFS_CHANGEPW_PASSWORD_CMD;
+        boolean isCyanogenmod13 = IS_M && SuShell.isCyanogenmod();
+
+        String command = isCyanogenmod13 ? CRYPTFS_CHANGEPW_PASSWORD_CM_CMD
+                                         : CRYPTFS_CHANGEPW_PASSWORD_CMD;
         if (PIN_PATTERN.matcher(newPassword).matches()) {
-            command = CRYPTFS_CHANGEPW_PIN_CMD;
+            command = isCyanogenmod13 ? CRYPTFS_CHANGEPW_PIN_CM_CMD
+                                      : CRYPTFS_CHANGEPW_PIN_CMD;
         }
         List<String> response = SuShell.run("su",
-                String.format(command, encodedPassword));
+                isCyanogenmod13 ? String.format(command, encodedPassword, encodedPassword)
+                                : String.format(command, encodedPassword));
 
         return checkVdcResponse(response);
     }


### PR DESCRIPTION
This fixes issues #14 and #15.

I have tested it on Nexus 5 with my [SnooperStopper](https://github.com/xmikos/SnooperStopper) fork.